### PR TITLE
Log fault message when build compute instance failed

### DIFF
--- a/huaweicloudstack/resource_huaweicloudstack_compute_instance_v2.go
+++ b/huaweicloudstack/resource_huaweicloudstack_compute_instance_v2.go
@@ -804,6 +804,11 @@ func ServerV2StateRefreshFunc(client *golangsdk.ServiceClient, instanceID string
 			return nil, "", err
 		}
 
+		// get fault message when status is ERROR
+		if s.Status == "ERROR" {
+			fault := fmt.Errorf("[error code: %d, message: %s]", s.Fault.Code, s.Fault.Message)
+			return s, "ERROR", fault
+		}
 		return s, s.Status, nil
 	}
 }


### PR DESCRIPTION
we can get the error message in fault field of querying response body.

The log message likes this:
Error: Error waiting for instance (instance_id) to become ready: [error code: 500, message: Build of instance instance_id aborted: Block Device Mapping is Invalid.]