### PR TITLE
Remove unused 'value_specs' parameter in some resources

### DIFF
--- a/website/docs/r/compute_keypair_v2.html.markdown
+++ b/website/docs/r/compute_keypair_v2.html.markdown
@@ -34,8 +34,6 @@ The following arguments are supported:
 * `public_key` - (Required) A pregenerated OpenSSH-formatted public key.
     Changing this creates a new keypair.
 
-* `value_specs` - (Optional) Map of additional options.
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/compute_servergroup_v2.html.markdown
+++ b/website/docs/r/compute_servergroup_v2.html.markdown
@@ -35,8 +35,6 @@ The following arguments are supported:
     the Policies section for more information. Changing this creates a new
     server group.
 
-* `value_specs` - (Optional) Map of additional options.
-
 ## Policies
 
 * `affinity` - All instances/servers launched in this group will be hosted on

--- a/website/docs/r/networking_floatingip_v2.html.markdown
+++ b/website/docs/r/networking_floatingip_v2.html.markdown
@@ -41,8 +41,6 @@ The following arguments are supported:
 * `fixed_ip` - Fixed IP of the port to associate with this floating IP. Required if
 the port has multiple fixed IPs.
 
-* `value_specs` - (Optional) Map of additional options.
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/networking_network_v2.html.markdown
+++ b/website/docs/r/networking_network_v2.html.markdown
@@ -84,8 +84,6 @@ The following arguments are supported:
 
 * `segments` - (Optional) An array of one or more provider segment objects.
 
-* `value_specs` - (Optional) Map of additional options.
-
 * `availability_zone_hints` -  (Optional) An availability zone is used to make
     network resources highly available. Used for resources with high availability
     so that they are scheduled on different availability zones. Changing this 

--- a/website/docs/r/networking_port_v2.html.markdown
+++ b/website/docs/r/networking_port_v2.html.markdown
@@ -78,8 +78,6 @@ The following arguments are supported:
     on the port. The structure is described below. Can be specified multiple
     times.
 
-* `value_specs` - (Optional) Map of additional options.
-
 The `fixed_ip` block supports:
 
 * `subnet_id` - (Required) Subnet in which to allocate IP address for

--- a/website/docs/r/networking_router_v2.html.markdown
+++ b/website/docs/r/networking_router_v2.html.markdown
@@ -57,8 +57,6 @@ The following arguments are supported:
 * `tenant_id` - (Optional) The owner of the floating IP. Required if admin wants
     to create a router for another tenant. Changing this creates a new router.
 
-* `value_specs` - (Optional) Map of additional driver-specific options.
-
 * `availability_zone_hints` -  (Optional) An availability zone is used to make 
     network resources highly available. Used for resources with high availability so that they are scheduled on different availability zones. Changing
     this creates a new router.
@@ -81,7 +79,6 @@ The following attributes are exported:
 * `enable_snat` - See Argument Reference above.
 * `external_fixed_ip` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
-* `value_specs` - See Argument Reference above.
 * `availability_zone_hints` - See Argument Reference above.
 
 ## Import

--- a/website/docs/r/networking_subnet_v2.html.markdown
+++ b/website/docs/r/networking_subnet_v2.html.markdown
@@ -72,8 +72,6 @@ The following arguments are supported:
     object structure is documented below. Changing this updates the host routes
     for the existing subnet.
 
-* `value_specs` - (Optional) Map of additional options.
-
 The `allocation_pools` block supports:
 
 * `start` - (Required) The starting address.


### PR DESCRIPTION
'value_specs' is never used, so remove it.