### PR TITLE
Update available values of 'volume_type' in as_configuration_v1

### DIFF
--- a/huaweicloudstack/resource_huaweicloudstack_as_configuration_v1.go
+++ b/huaweicloudstack/resource_huaweicloudstack_as_configuration_v1.go
@@ -82,9 +82,8 @@ func resourceASConfiguration() *schema.Resource {
 										Required: true,
 									},
 									"volume_type": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: resourceASConfigurationValidateVolumeType,
+										Type:     schema.TypeString,
+										Required: true,
 									},
 									"disk_type": {
 										Type:         schema.TypeString,
@@ -416,7 +415,7 @@ func resourceASConfigurationValidateDiskType(v interface{}, k string) (ws []stri
 	return
 }
 
-var VolumeTypes = [2]string{"SATA", "SSD"}
+var VolumeTypes = [3]string{"SAS", "SATA", "SSD"}
 
 func resourceASConfigurationValidateVolumeType(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)

--- a/website/docs/r/as_configuration_v1.html.markdown
+++ b/website/docs/r/as_configuration_v1.html.markdown
@@ -117,7 +117,7 @@ The `disk` block supports:
     and the data disk size ranges from 10 to 32768.
 
 * `volume_type` - (Required) The disk type, which must be the same as the disk type available in the system.
-    The options include `SATA` (common I/O disk type) and `SSD` (ultra-high I/O disk type).
+    The available types are `SSD`, `SAS`, `SATA` or other types defined in CCS.
 
 * `disk_type` - (Required) Whether the disk is a system disk or a data disk. Option `DATA` indicates
     a data disk. option `SYS` indicates a system disk.


### PR DESCRIPTION
The available types are `SSD`, `SAS`, `SATA` or other types defined in CCS.
so we don't check the validatation just passthrough to the API.

Signed-off-by: ShiChangkuo <shichangkuo90@gmail.com>