### PR TITLE
Validate parameters of huaweicloudstack provider

### DIFF
--- a/huaweicloudstack/config.go
+++ b/huaweicloudstack/config.go
@@ -57,6 +57,15 @@ func (c *Config) LoadAndValidate() error {
 		return fmt.Errorf("Invalid endpoint type provided")
 	}
 
+	if c.Password != "" {
+		if c.Username == "" && c.UserID == "" {
+			return fmt.Errorf("\"password\": one of `user_name, user_id` must be specified")
+		}
+		if c.TenantName != "" && c.DomainID == "" && c.DomainName == "" {
+			return fmt.Errorf("\"tenant_name\": one of `domain_name, domain_id` must be specified")
+		}
+	}
+
 	return newhwClient(c)
 
 }

--- a/huaweicloudstack/provider.go
+++ b/huaweicloudstack/provider.go
@@ -20,15 +20,17 @@ func Provider() terraform.ResourceProvider {
 			"access_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_ACCESS_KEY", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OS_ACCESS_KEY", nil),
 				Description: descriptions["access_key"],
+				Deprecated:  "not supported, please use password authentication",
 			},
 
 			"secret_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_SECRET_KEY", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OS_SECRET_KEY", nil),
 				Description: descriptions["secret_key"],
+				Deprecated:  "not supported, please use password authentication",
 			},
 
 			"auth_url": {
@@ -40,23 +42,25 @@ func Provider() terraform.ResourceProvider {
 
 			"region": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				Description: descriptions["region"],
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", nil),
 			},
 
 			"user_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USERNAME", ""),
-				Description: descriptions["user_name"],
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("OS_USERNAME", nil),
+				Description:   descriptions["user_name"],
+				ConflictsWith: []string{"user_id"},
 			},
 
 			"user_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USER_ID", ""),
-				Description: descriptions["user_name"],
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("OS_USER_ID", nil),
+				Description:   descriptions["user_name"],
+				ConflictsWith: []string{"user_name", "domain_name", "domain_id"},
 			},
 
 			"tenant_id": {
@@ -80,17 +84,18 @@ func Provider() terraform.ResourceProvider {
 			},
 
 			"password": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_PASSWORD", ""),
-				Description: descriptions["password"],
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				DefaultFunc:  schema.EnvDefaultFunc("OS_PASSWORD", nil),
+				Description:  descriptions["password"],
+				ExactlyOneOf: []string{"password", "token"},
 			},
 
 			"token": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_TOKEN", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_TOKEN", nil),
 				Description: descriptions["token"],
 			},
 
@@ -101,8 +106,9 @@ func Provider() terraform.ResourceProvider {
 					"OS_USER_DOMAIN_ID",
 					"OS_PROJECT_DOMAIN_ID",
 					"OS_DOMAIN_ID",
-				}, ""),
-				Description: descriptions["domain_id"],
+				}, nil),
+				Description:   descriptions["domain_id"],
+				ConflictsWith: []string{"domain_name"},
 			},
 
 			"domain_name": {
@@ -113,8 +119,9 @@ func Provider() terraform.ResourceProvider {
 					"OS_PROJECT_DOMAIN_NAME",
 					"OS_DOMAIN_NAME",
 					"OS_DEFAULT_DOMAIN",
-				}, ""),
-				Description: descriptions["domain_name"],
+				}, nil),
+				Description:   descriptions["domain_name"],
+				ConflictsWith: []string{"domain_id"},
 			},
 
 			"insecure": {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -70,20 +70,11 @@ provider "huaweicloudstack" {
 
 The following arguments are supported:
 
-* `access_key` - (Optional) The access key of the HuaweiCloudStack to use.
-  If omitted, the `OS_ACCESS_KEY` environment variable is used.
-
-* `secret_key` - (Optional) The secret key of the HuaweiCloudStack to use.
-  If omitted, the `OS_SECRET_KEY` environment variable is used.
-
 * `auth_url` - (Required) The Identity authentication URL. If omitted, the
   `OS_AUTH_URL` environment variable is used.
 
-* `region` - (Optional) The region of the HuaweiCloudStack to use. If omitted,
-  the `OS_REGION_NAME` environment variable is used. If `OS_REGION_NAME` is
-  not set, then no region will be used. It should be possible to omit the
-  region in single-region HuaweiCloudStack environments, but this behavior may vary
-  depending on the HuaweiCloudStack environment being used.
+* `region` - (Required) The region of the HuaweiCloudStack to use. If omitted,
+  the `OS_REGION_NAME` environment variable is used.
 
 * `user_name` - (Optional) The Username to login with. If omitted, the
   `OS_USERNAME` environment variable is used.
@@ -99,8 +90,8 @@ The following arguments are supported:
   (Identity v3) to login with. If omitted, the `OS_TENANT_NAME` or
   `OS_PROJECT_NAME` environment variable are used.
 
-* `password` - (Optional) The Password to login with. If omitted, the
-  `OS_PASSWORD` environment variable is used.
+* `password` - (Optional; Required if not using `token`) The Password to login with.
+  If omitted, the `OS_PASSWORD` environment variable is used.
 
 * `token` - (Optional; Required if not using `user_name` and `password`)
   A token is an expiring, temporary means of access issued via the Keystone
@@ -139,6 +130,13 @@ The following arguments are supported:
 * `endpoints` - (Optional) Specify the custom endpoints in key/value pairs, which
   used to override the default endpoint URL constructed from the region.
   The available keys include `as`, `ecs`, `evs`, `ims`, `vpc`, `kms`.
+
+* `access_key` - (Deprecated) The access key of the HuaweiCloudStack to use.
+  If omitted, the `OS_ACCESS_KEY` environment variable is used.
+
+* `secret_key` - (Deprecated) The secret key of the HuaweiCloudStack to use.
+  If omitted, the `OS_SECRET_KEY` environment variable is used.
+
 
 ## Additional Logging
 


### PR DESCRIPTION
add the follow rules:
- `user_name` and `user_id` are alternative;
- `domain_name` and `domain_id` are alternative;
- `domain_name` and `domain_id` can not be set together with `user_id`;
- only one of the`password` and `token`can be specified;
- one of `user_name`, `user_id` must be specified  together with `password`;
- one of `domain_name` and `domain_id` must be specified together with `tenant_name` in  password mode;
- mark `access_key` and `secret_key` deprecated as the provider doesn't support AKSK;